### PR TITLE
Added Host Security Options via ENV file

### DIFF
--- a/.envNFS
+++ b/.envNFS
@@ -1,0 +1,2 @@
+NFS_CONFIG_TEMPLATE=(rw,sync,insecure,no_subtree_check,no_root_squash)
+NFS_CONFIG_HOSTS=10.0.0.1,10.0.0.2

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -15,15 +15,23 @@ trap "shutdown" SIGTERM
 ####
 
 echo "Export points:"
+#### Add Root SharePoint
 echo "$export_base *(rw,sync,insecure,fsid=0,no_subtree_check,no_root_squash)" | tee /etc/exports
 
+#### Add Folders from Docker start command and add config for folder in /etc/exports
 read -a exports <<< "${@}"
 for export in "${exports[@]}"; do
     src=`echo "$export" | sed 's/^\///'` # trim the first '/' if given in export path
-    src="$export_base$src"
+    src="$export_base$src" #add export_base
     mkdir -p $src
     chmod 777 $src
-    echo "$src *(rw,sync,insecure,no_subtree_check,no_root_squash)" | tee -a /etc/exports
+	line="$src "
+	while IFS=',' read -ra HOSTS; do
+		for i in "${HOSTS[@]}"; do
+			line="$line $i$NFS_CONFIG_TEMPLATE"
+		done
+	done <<< $NFS_CONFIG_HOSTS
+    echo "$line" | tee -a /etc/exports
 done
 
 echo -e "\n- Initializing nfs server.."

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-docker run -d --name mynfs --privileged docker.io/erezhorev/dockerized_nfs_server $@
+docker run -d --name mynfs --privileged --env-file=.envNFS docker.io/erezhorev/dockerized_nfs_server $@
 
 # Source the script to populate MYNFSIP env var
 export MYNFSIP=$(docker inspect -f '{{.NetworkSettings.IPAddress}}' mynfs)


### PR DESCRIPTION
First of all, I think your Repo is great and it really helped me out, but I think you should increase the security configuration a bit. In your approach you allow connections form every IP Adress (/etc/export - /path/to/export *(rw,sync...)) I thought why don't you add permissions for predefined IPs only. 

Therefore, I created a new .env file which can be added to the docker run command and provides the NFS options. In the run.sh script I separate the IPs and add the NFS_CONFIG_TEMPLATE for each IP. 

```
/exports/a       10.0.0.1(rw,sync,insecure,no_subtree_check,no_root_squash) 10.0.0.2(rw,sync,insecure,no_subtree_check,no_root_squash)
/exports/b       10.0.0.1(rw,sync,insecure,no_subtree_check,no_root_squash) 10.0.0.2(rw,sync,insecure,no_subtree_check,no_root_squash)
```
Now only those IPs can mount the directories and everybody is happy